### PR TITLE
http -> https in curl command to get GPG key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN yum -y install \
          which \
          openssh-clients && \
     yum -y groupinstall 'Development Tools' && \
-    curl -O http://research.cs.wisc.edu/htcondor/yum/RPM-GPG-KEY-HTCondor && \
+    curl -O https://research.cs.wisc.edu/htcondor/yum/RPM-GPG-KEY-HTCondor && \
     rpm --import RPM-GPG-KEY-HTCondor && \
     yum-config-manager --add-repo https://research.cs.wisc.edu/htcondor/yum/repo.d/htcondor-development-rhel7.repo && \
     yum -y install condor-bosco && \


### PR DESCRIPTION
Building a new image from the Dockerfile failed, because research.cs.wisc.edu forwards http to https and therefore line 18 just downloaded the "301 Moved Permanently" html response.